### PR TITLE
Fix open source field 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.vscode
 meta/

--- a/main.py
+++ b/main.py
@@ -307,7 +307,7 @@ def parse_idea(
         "proposal_title": strip_tags(idea["title"]),
         "proposal_url": idea["url"],
         "files_url": {
-            "open_source": idea["customFieldsByKey"]["f10_open_source"],
+            "open_source": idea["customFieldsByKey"]["f10_open_source_choice"],
             "external_link1": idea["customFieldsByKey"]["f10_external_link"],
             "external_link2": idea["customFieldsByKey"]["f10_external_link_2"],
             "external_link3": idea["customFieldsByKey"]["f10_external_link_3"],


### PR DESCRIPTION
Fixed getting open source field, changed from `f10_open_source` to `f10_open_source_choice`, taking only "yes"/"no" answers.